### PR TITLE
Add 3D print ecommerce backend skeleton

### DIFF
--- a/3d_print_ecommerce/README.md
+++ b/3d_print_ecommerce/README.md
@@ -1,0 +1,17 @@
+# 3D Print E-commerce Prototype
+
+This directory contains a simple prototype of a 3D print e-commerce application based on FastAPI for the backend. A minimal Vue frontend would go in the `frontend/` directory.
+
+## Backend
+
+The backend exposes endpoints for uploading STL files and managing orders. Data is stored in a local SQLite database, and uploaded files are stored in the `uploads/` directory.
+
+To run the backend (assuming dependencies are installed):
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+## Frontend
+
+The frontend directory is currently a placeholder for a Vue.js application.

--- a/3d_print_ecommerce/backend/database.py
+++ b/3d_print_ecommerce/backend/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///./database.sqlite'
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/3d_print_ecommerce/backend/main.py
+++ b/3d_print_ecommerce/backend/main.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi import Depends
+from sqlalchemy.orm import Session
+from . import models, database
+import shutil
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+models.Base.metadata.create_all(bind=database.engine)
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post("/upload-stl")
+async def upload_stl(file: UploadFile = File(...)):
+    file_location = f"uploads/{file.filename}"
+    try:
+        with open(file_location, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"filename": file.filename}
+
+@app.post("/orders")
+def create_order(order: models.OrderCreate, db: Session = Depends(get_db)):
+    db_order = models.Order(**order.dict())
+    db.add(db_order)
+    db.commit()
+    db.refresh(db_order)
+    return db_order
+
+@app.get("/orders/{order_id}")
+def read_order(order_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Order).filter(models.Order.id == order_id).first()

--- a/3d_print_ecommerce/backend/models.py
+++ b/3d_print_ecommerce/backend/models.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Order(Base):
+    __tablename__ = "orders"
+    id = Column(Integer, primary_key=True, index=True)
+    customer_name = Column(String)
+    customer_email = Column(String)
+    status = Column(String)
+    stl_file = Column(String)
+    material = Column(String)
+    color = Column(String)
+    size = Column(String)
+    price = Column(Float)
+    stripe_payment_intent = Column(String)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class OrderCreate(BaseModel):
+    customer_name: str
+    customer_email: str
+    status: str = "pending"
+    stl_file: str
+    material: str
+    color: str
+    size: str
+    price: float
+    stripe_payment_intent: str

--- a/3d_print_ecommerce/backend/requirements.txt
+++ b/3d_print_ecommerce/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+SQLAlchemy
+pydantic

--- a/3d_print_ecommerce/frontend/README.md
+++ b/3d_print_ecommerce/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend Placeholder
+
+This directory is intended for a Vue.js application that interacts with the FastAPI backend.


### PR DESCRIPTION
## Summary
- set up a `3d_print_ecommerce` folder for a new example project
- implement a FastAPI backend with simple upload and order endpoints
- define an `Order` model via SQLAlchemy and Pydantic
- add a README explaining how to run the backend and placeholder frontend directory

## Testing
- `python3 -m py_compile 3d_print_ecommerce/backend/*.py`
- `pytest`